### PR TITLE
Doc: Avoid ambiguity in documentation of anonymous function/do keyword

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -923,7 +923,7 @@ map([A, B, C]) do x
 end
 ```
 
-The `do x` syntax creates an anonymous function with argument `x` and passes it as the first argument
+The `do x` syntax creates an anonymous function with argument `x` and passes it (i.e., the anonymous function) as the first argument
 to [`map`](@ref). Similarly, `do a,b` would create a two-argument anonymous function. Note that `do (a,b)` would create a one-argument anonymous function,
 whose argument is a tuple to be deconstructed. A plain `do` would declare that what follows is an anonymous function of the form `() -> ...`.
 


### PR DESCRIPTION
I find the [documentation of the `do` keyword](https://github.com/JuliaLang/julia/blob/0afa354c1f19c7fee7bd3dcb2ccefcb4bca5d85e/doc/src/manual/functions.md?plain=1#L926-L927) suboptimal, as there is some ambiguity what the **it** in the sentence below is referring to:

```md
The `do x` syntax creates an anonymous function with argument `x` and passes **it** as the first argument
to [`map`](@ref).
```

If you come across this concept for the first time it might not be clear that with this **it** the anonymous function is meant and not the argument `x` (which could be a valid choice if the anonymous function would alter `x`, i.e., resemble behaviour like `f!(x)`).